### PR TITLE
他のタブが更新されたら現在のタブの表示も更新するように

### DIFF
--- a/js/newTabNote.js
+++ b/js/newTabNote.js
@@ -41,6 +41,15 @@ editInput.addEventListener("input", () => {
   editInput.style.height = lines * editInputLineHeight;
 });
 
+// 他のタブが更新されたら現在のタブの表示も更新するように
+window.addEventListener("storage", (event) => {
+  if (event.key === "new_tab_note") {
+    const newVal = event.newValue
+    editInput.value = newVal.replace(/\s+$/, "");
+    previewWindow.innerHTML = marked(newVal);
+  }
+})
+
 editInput.addEventListener("keydown", (e) => {
   if (!e) return;
 


### PR DESCRIPTION
他のタブで編集して、更新を気づかずに他のタブで上書きしてしまうことがあったため。

参考: 
https://developer.mozilla.org/ja/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#responding_to_storage_changes_with_the_storageevent
https://qiita.com/nakajmg/items/d1b90ba9bc56e7575a6a