### PR TITLE
feat: mode: editのときに横幅を縮める

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -286,6 +286,11 @@ blockquote p {
   border: none;
 }
 
+.edit-input.edit-only {
+  padding-right: 20%;
+  padding-left: 20%; 
+}
+
 .edit-input.filter {
   filter: blur(5px);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -286,7 +286,7 @@ blockquote p {
   border: none;
 }
 
-.edit-input.edit-only {
+.edit-window.edit-only {
   padding-right: 20%;
   padding-left: 20%; 
 }

--- a/js/newTabNote.js
+++ b/js/newTabNote.js
@@ -119,18 +119,21 @@ function setListPoint(regex, targetSentence, cursorPosition) {
 // Mode button
 modeEditButton.addEventListener("click", (e) => {
   editWindow.classList.remove("none");
+  editWindow.classList.add("edit-only");
   previewWindow.classList.add("none");
   modeHandler.saveMode("mode-edit");
   modeButtonStatus(e);
 });
 modeSplitButton.addEventListener("click", (e) => {
   editWindow.classList.remove("none");
+  editWindow.classList.remove("edit-only");
   previewWindow.classList.remove("none");
   modeHandler.saveMode("mode-split");
   modeButtonStatus(e);
 });
 modePreviewButton.addEventListener("click", (e) => {
   editWindow.classList.add("none");
+  editWindow.classList.remove("edit-only");
   previewWindow.classList.remove("none");
   modeHandler.saveMode("mode-preview");
   modeButtonStatus(e);


### PR DESCRIPTION
## 変更内容
editモードのとき、記入内容が左に寄りすぎてしまい視認性が悪く感じることがありました。
![image](https://user-images.githubusercontent.com/60059787/150181394-7da3afbf-d740-463b-a4ee-bc5bda8d84f9.png)

これを改善するため、editモードのときは`padding-right`, `padding-left`の値を増やす変更をしました。
![image](https://user-images.githubusercontent.com/60059787/150181777-75712fbf-e801-40bc-bf82-dc42fd915fed.png)


