### PR TITLE
fix: previewエリアのpadding, marginを修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -245,7 +245,7 @@ blockquote p {
   box-sizing: border-box;
   min-width: 50%;
   height: 100%;
-  padding: 80px 30px 30px;
+  padding: 50px 30px 30px;
   overflow: scroll
 }
 
@@ -316,6 +316,6 @@ blockquote p {
   display: none
 }
 
-.preview h1:first-child {
+.preview *:first-child {
   margin-top: 0
 }


### PR DESCRIPTION
## 問題
editとpreviewのpadding-topの値が異なっており、並べたときにズレが生じています。
![image](https://user-images.githubusercontent.com/60059787/150183447-adab6116-9dfe-4502-96a3-28139e5d1641.png)


## 変更内容
- `.preview`の`padding-top`を`.edit`と揃えました
- プレビューエリアの最初の要素において、`h1`以外でも`margin-top`を0に揃えました

![image](https://user-images.githubusercontent.com/60059787/150183405-303a5239-154b-46d2-9d52-34ebb86da8f8.png)
